### PR TITLE
Boldify local author names

### DIFF
--- a/src/coffeehandlers.py
+++ b/src/coffeehandlers.py
@@ -529,7 +529,7 @@ class ArticleListHandler(tornado.web.RequestHandler):
                 LOGGER.warning('no papers for today yet, '
                                'redirecting to previous day papers')
 
-                (latestdate, local_articles,
+                (latestdate, local_articles, flagged_local_authors,
                  voted_articles, other_articles, reserved_articles) = (
                      arxivdb.get_articles_for_listing(
                          database=self.database
@@ -552,6 +552,7 @@ class ArticleListHandler(tornado.web.RequestHandler):
                             local_today=local_today,
                             todays_date=todays_date,
                             local_articles=local_articles,
+                            flagged_local_authors=flagged_local_authors,
                             voted_articles=voted_articles,
                             other_articles=other_articles,
                             reserved_articles=reserved_articles,
@@ -591,7 +592,7 @@ class ArticleListHandler(tornado.web.RequestHandler):
         else:
 
             # get the articles for today
-            (latestdate, local_articles,
+            (latestdate, local_articles, flagged_local_authors,
              voted_articles, other_articles, reserved_articles) = (
                  arxivdb.get_articles_for_listing(utcdate=todays_utcdate,
                                                   database=self.database)
@@ -624,6 +625,7 @@ class ArticleListHandler(tornado.web.RequestHandler):
                         local_today=local_today,
                         todays_date=todays_date,
                         local_articles=local_articles,
+                        flagged_local_author=flagged_local_authors,
                         voted_articles=voted_articles,
                         other_articles=other_articles,
                         reserved_articles=reserved_articles,
@@ -1440,7 +1442,7 @@ class ArchiveHandler(tornado.web.RequestHandler):
                 listingdate = '%s-%s-%s' % (year, month, day)
 
                 # get the articles for today
-                (latestdate, local_articles,
+                (latestdate, local_articles, flagged_local_authors,
                  voted_articles, other_articles, reserved_articles) = (
                      arxivdb.get_articles_for_listing(utcdate=listingdate,
                                                       database=self.database)
@@ -1494,6 +1496,7 @@ class ArchiveHandler(tornado.web.RequestHandler):
                                 local_today=local_today,
                                 todays_date=archive_datestr,
                                 local_articles=local_articles,
+                                flagged_local_authors=flagged_local_authors,
                                 voted_articles=voted_articles,
                                 other_articles=other_articles,
                                 reserved_articles=reserved_articles,

--- a/src/static/templates/listing.html
+++ b/src/static/templates/listing.html
@@ -75,7 +75,10 @@
 
             <div class="row">
               <div class="small-12 columns">
-                <h6 class="subheader">{{ ', '.join((article[4].split(': ')[-1]).split(',')) }}</h6>
+                {% set authors_raw = (article[4].split(': ')[-1]).split(',') %}
+                {% set authors = [a if a not in flagged_local_authors else '<b>{0}</b>'.format(a) for a in authors_raw] %}
+
+                <h6 class="subheader">{{ ', '.join(authors) }}</h6>
                 {% if len(article[5]) > 0 %}
                 <p class="comments-para">{% raw article[5] %}</p>
                 {% end %}


### PR DESCRIPTION
Here's one possible way to do it, but, full disclosure, I don't have a local installation to test whether this actually works.

I could also see modifying the database so that on initial parsing, `local_authors` becomes a string with all the local author names rather than a boolean flag. But I opted for not changing the database structure at the expense of performance...

Anyways, I should probably set up a local copy to test, but I wanted to first put up this idea to see if you had any better ideas.